### PR TITLE
implemented Products and animations on hovering

### DIFF
--- a/src/components/ProductItem.jsx
+++ b/src/components/ProductItem.jsx
@@ -1,11 +1,79 @@
 import React from "react";
 import styled from "styled-components";
+import {FavoriteBorderOutlined, SearchOutlined, ShoppingCartOutlined} from "@mui/icons-material";
 
-const Container = styled.div``
+const Info = styled.div`
+  opacity: 0;
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  left: 0;
+  background-color: rgba(0, 0, 0, 0.2);
+  z-index: 3;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.5s ease;
+  cursor: pointer;
+`
+const Container = styled.div`
+  flex: 1;
+  margin: 5px;
+  min-width: 280px;
+  height: 350px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: #f5fbfd;
+  position: relative;
+  
+  &:hover ${Info}{       // when we hover to the container only then Info will be displayed and opacity changed to 1; by default we made it 0
+    opacity: 1;
+  }
+`
+const Circle = styled.div`
+   width: 200px;
+  height: 200px;
+  border-radius: 50%;
+  background-color: white;
+  position: absolute;
+`
+const Image = styled.img`
+  height: 75%;
+  z-index: 2; // use to put item on top of another item
+`
+const Icon = styled.div`
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background-color: white;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 10px;
+  transition: all 0.5s ease;    // provided animation to hover
+  &:hover {
+    background-color: #e9f5f5;
+    transform: scale(1.1);  // provided animation to large it up when hovered
+  }
+`
 const ProductItem = ({item}) => {
     return (
         <Container>
-            hello
+            <Circle/>
+            <Image src={item.img} />
+            <Info>
+                <Icon>
+                    <ShoppingCartOutlined/>
+                </Icon>
+                <Icon>
+                    <SearchOutlined/>
+                </Icon>
+                <Icon>
+                    <FavoriteBorderOutlined/>
+                </Icon>
+            </Info>
         </Container>
     )
 }

--- a/src/components/Products.jsx
+++ b/src/components/Products.jsx
@@ -3,7 +3,12 @@ import styled from "styled-components";
 import { products } from "../images/Products"
 import ProductItem from "./ProductItem";
 
-const Container = styled.div``
+const Container = styled.div`
+  padding: 20px;
+  display: flex;
+  flex-wrap: wrap; // to wrap the objects in a container
+  justify-content: space-between;
+`
 
 const Products = () => {
     return (


### PR DESCRIPTION
```
 &:hover ${Info}{       // when we hover to the container only then Info will be displayed and opacity changed to 1; by default we made it 0
    opacity: 1;
  }
```

```
z-index: 2; // use to put item on top of another item
```

<img width="1726" alt="Screenshot 2023-09-07 at 5 09 59 PM" src="https://github.com/himani501/DreamShoppe/assets/55596492/3eed50cf-c0c1-4e1c-9f39-df446c651a74">
